### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/chrome/croscin.js
+++ b/src/chrome/croscin.js
@@ -218,8 +218,9 @@ croscin.IME = function() {
     var buffer_text = buffer.join('');
     var all_text = buffer_text + keystroke;
     self.log("croscin.UpdateComposition:", all_text);
-    if (typeof(cursor) == undefined)
+    if (typeof cursor === 'undefined'){
       cursor = all_text.length;
+    }
     if (all_text) {
       arg.cursor = cursor;
       // Selection to show where keystrokes are.


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`. 

As typeof returns a string it should compare to `'undefined'`.