### PR TITLE
Fix issue 21 text cleared on focus

### DIFF
--- a/src/chrome/croscin.js
+++ b/src/chrome/croscin.js
@@ -254,11 +254,10 @@ croscin.IME = function() {
     } else {
       // crbug.com/303639: if cursor was not zero, calling clearComposition
       // would do nothing. This is found when we start implementing lcch.
+      self.ime_api.clearComposition(arg);
       arg.text = '';
       arg.cursor = 0;
       self.ime_api.setComposition(arg);
-      arg = self.GetContextArg();
-      self.ime_api.clearComposition(arg);
     }
     return all_text;
   }

--- a/src/chrome/croscin.js
+++ b/src/chrome/croscin.js
@@ -252,12 +252,7 @@ croscin.IME = function() {
       }
       self.ime_api.setComposition(arg);
     } else {
-      // crbug.com/303639: if cursor was not zero, calling clearComposition
-      // would do nothing. This is found when we start implementing lcch.
       self.ime_api.clearComposition(arg);
-      arg.text = '';
-      arg.cursor = 0;
-      self.ime_api.setComposition(arg);
     }
     return all_text;
   }


### PR DESCRIPTION
Just revert two commits. I don't see a bug described in the comment (crbug.com/303639). Maybe it's been resolved from the API side.

Test:
1. Input one character, it shows IME dialog. Press backspace, IME dialog disappears.
2. Input two characters, it shows IME dialog. Press backspace twice, IME dialog disappears.
3. Enable IME, change focus to URL, the URL text still exists
4. In the URL box with texts, put the cursor in any position. Enable/disable IME and input characters and backspace. No unexpected text cleared or added.
